### PR TITLE
Preset window improvements

### DIFF
--- a/data/ui/presets_manager_window.blp
+++ b/data/ui/presets_manager_window.blp
@@ -146,3 +146,18 @@ template GradiencePresetWindow : Adw.Window {
     }
   }
 }
+
+Gtk.FileChooserNative import_file_chooser {
+  title: _("Import a Preset File (*.json)");
+  modal: true;
+}
+
+Gtk.FileFilter all_filter {
+  name: _("All files");
+  mime-types ["application/octet-stream"]
+}
+
+Gtk.FileFilter json_filter {
+  name: _("JSON file (*.json)");
+  mime-types ["application/json"]
+}

--- a/src/builtin_preset_row.py
+++ b/src/builtin_preset_row.py
@@ -1,3 +1,21 @@
+# builtin_preset_row.py
+#
+# Change the look of Adwaita, with ease
+# Copyright (C) 2022  Gradience Team
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 from gi.repository import Gtk, Adw
 
 from .constants import rootdir

--- a/src/modules/custom_presets.py
+++ b/src/modules/custom_presets.py
@@ -20,50 +20,76 @@ import os
 import json
 import urllib3
 
-from .utils import to_slug_case
+from .utils import to_slug_case, buglog
 
 
 # Open an pool manager
 poolmgr = urllib3.PoolManager()
 
 
-def fetch_presets(repo):
+def fetch_presets(repo) -> [dict, list]:
     try:
         http = poolmgr.request("GET", repo)
+    except urllib3.exceptions.NewConnectionError as e: # offline
+        buglog(f"Failed to establish a new connection. Exc: {e}")
+        return False, False
+    except urllib3.exceptions.MaxRetryError as e:
+        buglog(f"Maximum number of retries exceeded. Exc: {e}")
+        return False, False
+    except urllib3.exceptions.HTTPError as e:
+        buglog(f"Unhandled urllib3.exceptions.HTTPError error code. Exc: {e}")
+        return False, False
+    
+    try:
         raw = json.loads(http.data)
-
-        preset_dict = {}
-        url_list = []
-
-        for data in raw.items():
-            data = list(data)
-            data.insert(0, to_slug_case(data[0]))
-
-            url = data[2]
-            data.pop(2)  # Remove preset URL from list
-
-            to_dict = iter(data)
-            # Convert list back to dict
-            preset_dict.update(dict(zip(to_dict, to_dict)))
-
-            url_list.append(url)
-
-        return preset_dict, url_list
-    except Exception:  # offline
+    except json.JSONDecodeError as e:
+        buglog(f"Error with decoding JSON data. Exc: {e}")
         return False, False
 
+    preset_dict = {}
+    url_list = []
 
-def download_preset(name, repo_name, url):
+    for data in raw.items():
+        data = list(data)
+        data.insert(0, to_slug_case(data[0]))
+
+        url = data[2]
+        data.pop(2)  # Remove preset URL from list
+
+        to_dict = iter(data)
+        # Convert list back to dict
+        preset_dict.update(dict(zip(to_dict, to_dict)))
+
+        url_list.append(url)
+
+    return preset_dict, url_list
+
+def download_preset(name, repo_name, url) -> None:
     try:
         http = poolmgr.request("GET", url)
+    except urllib3.exceptions.NewConnectionError as e: # offline
+        buglog(f"Failed to establish a new connection. Exc: {e}")
+        return False, False
+    except urllib3.exceptions.MaxRetryError as e:
+        buglog(f"Maximum number of retries exceeded. Exc: {e}")
+        return False, False
+    except urllib3.exceptions.HTTPError as e:
+        buglog(f"Unhandled urllib3.exceptions.HTTPError error code. Exc: {e}")
+        return False, False
+
+    try:
         raw = json.loads(http.data)
+    except json.JSONDecodeError as e:
+        buglog(f"Error with decoding JSON data. Exc: {e}")
+        return False, False
 
-        data = json.dumps(raw)
+    data = json.dumps(raw)
 
+    try:
         with open(
             os.path.join(
                 os.environ.get("XDG_CONFIG_HOME",
-                               os.environ["HOME"] + "/.config"),
+                                os.environ["HOME"] + "/.config"),
                 "presets",
                 repo_name,
                 to_slug_case(name) + ".json",
@@ -72,5 +98,5 @@ def download_preset(name, repo_name, url):
         ) as f:
             f.write(data)
             f.close()
-    except Exception:
-        return False, False
+    except OSError as e:
+        buglog(f"Failed to write data into a file. Exc: {e}")

--- a/src/modules/custom_presets.py
+++ b/src/modules/custom_presets.py
@@ -26,7 +26,7 @@ from .utils import to_slug_case, buglog
 # Open an pool manager
 poolmgr = urllib3.PoolManager()
 
-
+# TODO: Modify functions to be asynchronous
 def fetch_presets(repo) -> [dict, list]:
     try:
         http = poolmgr.request("GET", repo)
@@ -99,4 +99,4 @@ def download_preset(name, repo_name, url) -> None:
             f.write(data)
             f.close()
     except OSError as e:
-        buglog(f"Failed to write data into a file. Exc: {e}")
+        buglog(f"Failed to write data to a file. Exc: {e}")

--- a/src/modules/utils.py
+++ b/src/modules/utils.py
@@ -22,19 +22,17 @@ import logging
 from anyascii import anyascii
 from gradience.constants import build_type
 
+
 if build_type == "debug":
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.DEBUG, format="[%(levelname)s] [%(name)s] %(message)s")
 else:
-    logging.basicConfig(level=logging.WARNING)
+    logging.basicConfig(level=logging.WARNING, format="[%(levelname)s] [%(name)s] %(message)s")
 
 
 def to_slug_case(non_slug):
     return re.sub(r"[^0-9a-z]+", "-", anyascii(non_slug).lower()).strip("-")
 
-
 # Use it instead of print(), so there isn't any output in stdout if
-# Gradience was build in release mode
-
-
+# Gradience is build in release mode
 def buglog(*args):
     logging.debug(*args)

--- a/src/preset_row.py
+++ b/src/preset_row.py
@@ -202,9 +202,6 @@ class GradiencePresetRow(Adw.ActionRow):
                 self.toast_overlay.add_toast(
                     Adw.Toast(title=_("Unable to delete preset"))
                 )
-            else:
-                self.toast_overlay.add_toast(
-                    Adw.Toast(title=_("Preset removed")))
             finally:
                 self.win.reload_pref_group()
         else:

--- a/src/preset_row.py
+++ b/src/preset_row.py
@@ -178,7 +178,7 @@ class GradiencePresetRow(Adw.ActionRow):
                     ),
                 )
             except Exception as exception:
-                print(exception.with_traceback())
+                buglog(exception)
             finally:
                 self.win.reload_pref_group()
 
@@ -198,7 +198,7 @@ class GradiencePresetRow(Adw.ActionRow):
                     )
                 )
             except Exception as exception:
-                print(exception.with_traceback())
+                buglog(exception)
                 self.toast_overlay.add_toast(
                     Adw.Toast(title=_("Unable to delete preset"))
                 )
@@ -225,7 +225,7 @@ class GradiencePresetRow(Adw.ActionRow):
                     ),
                 )
             except Exception as exception:
-                print(exception.with_traceback())
+                buglog(exception)
             finally:
                 self.win.reload_pref_group()
 

--- a/src/presets_manager_window.py
+++ b/src/presets_manager_window.py
@@ -121,6 +121,9 @@ class GradiencePresetWindow(Adw.Window):
         self.reload_repos_group()
 
     def setup_explore(self):
+        self.search_results_list.clear()
+        buglog("Preset list cleared")
+        
         offline = False
 
         for repo_name, repo in self._repos.items():
@@ -211,6 +214,7 @@ class GradiencePresetWindow(Adw.Window):
     def on_search_changed(self, *args):
         search_text = self.search_entry.props.text
         buglog("[New search query]")
+        buglog(f"Presets amount: {len(self.search_results_list)}")
         buglog(f"Search string: {search_text}")
         buglog("Items found:")
         for widget in self.search_results_list:
@@ -218,8 +222,6 @@ class GradiencePresetWindow(Adw.Window):
                 widget.props.visible = True
             else:
                 widget.props.visible = False
-                buglog("Matching {} with {}".format(
-                    search_text, widget.props.title))
                 if search_text.lower() in widget.props.title.lower():
                     widget.props.visible = True
                     buglog(widget.props.title)

--- a/src/presets_manager_window.py
+++ b/src/presets_manager_window.py
@@ -172,6 +172,8 @@ class GradiencePresetWindow(Adw.Window):
             body_use_markup=True,
         )
 
+        #TODO: Fix "assertion 'adw_message_dialog_has_response (self, response)' failed" error \
+        # (don't know if this isn't a bug in libadwaita itself)
         dialog.add_response("cancel", _("Cancel"))
         dialog.add_response("add", _("Add"))
         dialog.set_response_appearance("add", Adw.ResponseAppearance.SUGGESTED)
@@ -191,8 +193,7 @@ class GradiencePresetWindow(Adw.Window):
 
         name_entry.connect("changed", on_name_entry_change)
 
-        url_entry = Gtk.Entry(placeholder_text="URL")
-        url_entry.set_text("https://website.com/raw/presets.json")
+        url_entry = Gtk.Entry(placeholder_text="https://website.com/raw/presets.json")
 
         def on_url_entry_change(*_args):
             if len(url_entry.get_text()) == 0:
@@ -357,7 +358,16 @@ class GradiencePresetWindow(Adw.Window):
             )
         )
 
-        if self.custom_presets:
+        buglog(f"custom_presets values: {self.custom_presets.values()}")
+
+        presets_check = not (
+            len(self.custom_presets["user"]) == 0
+            and len(self.custom_presets["official"]) == 0
+            and len(self.custom_presets["curated"]) == 0
+        )
+        buglog(f"preset_check: {presets_check}")
+
+        if presets_check:
             for repo, presets in self.custom_presets.items():
                 for preset, preset_name in presets.items():
                     row = GradiencePresetRow(preset_name, self, repo)


### PR DESCRIPTION
### Changes:
- Make `presets_manager_window` more readable, by moving some code into new functions,
- Always clear `search_results_list` to avoid Gtk warnings about non-child objects,
- Remove duplicate toast, that was showing up, when removing a preset,
- Add more `try ... except` statements to `custom_presets` module for easier debugging,
- Convert more print() functions to buglog(), and fix exception messages not showing up in `preset_row.py`,
- Fix `preset_empty` ActionRow not showing when user doesn't have any presets