### PR TITLE
Add margins to 'Custom CSS' TextView

### DIFF
--- a/data/ui/custom_css_group.blp
+++ b/data/ui/custom_css_group.blp
@@ -16,7 +16,11 @@ template GradienceCustomCSSGroup : Adw.PreferencesGroup {
     min-content-height: 500;
     max-content-height: 500;
     TextView custom-css-text-view {
-      styles ["custom-css-view", "card"]
+      styles ["card"]
+      left-margin: 10;
+      right-margin: 10;
+      top-margin: 10;
+      bottom-margin: 10;
       monospace: true;
       buffer: TextBuffer {
         changed => on_custom_css_changed();


### PR DESCRIPTION
Just a quick UI change to 'Custom CSS' TextView in Advanced tab.
<br>

Without margins:
![Screenshot from 2022-09-10 22-35-19](https://user-images.githubusercontent.com/73042332/189500880-2990ed56-5171-4d34-a8d6-9728524139ef.png)

With margins:
![Screenshot from 2022-09-10 22-34-26](https://user-images.githubusercontent.com/73042332/189500882-9ef6ff6c-479b-433e-ae26-84d880dad3cf.png)
