### PR TITLE
fix: change button text on warning

### DIFF
--- a/data/ui/welcome.blp
+++ b/data/ui/welcome.blp
@@ -74,7 +74,7 @@ template GradienceWelcomeWindow: Adw.Window {
 
                             Gtk.Button btn_agree {
                                 styles ["suggested-action", "pill"]
-                                label: _("I agree");
+                                label: _("Ok");
                                 use-underline: true;
                                 halign: center;
                             }


### PR DESCRIPTION
As "I agree" is an odd way to signal acknowledgement of a warning, change button text to the more standard "Ok".

## Changelog

- Changed warning button text to "Ok"