### PR TITLE
Revert: style: break up long lines #476

### DIFF
--- a/gradience/main.py
+++ b/gradience/main.py
@@ -585,8 +585,7 @@ class GradienceApplication(Adw.Application):
         dialog = GradienceAppTypeDialog(
             _("Apply this color scheme?"),
             _(
-                "Warning: any custom CSS files for those app types will be \
-				irreversibly overwritten!"
+                "Warning: any custom CSS files for those app types will be irreversibly overwritten!"
             ),
             "apply",
             _("Apply"),
@@ -626,8 +625,7 @@ class GradienceApplication(Adw.Application):
             transient_for=self.props.active_window,
             heading=_("Save preset as..."),
             body=_(
-                "Saving preset to <tt>{0}</tt>. If that preset already \
-				exists, it will be overwritten!"
+                "Saving preset to <tt>{0}</tt>. If that preset already exists, it will be overwritten!"
             ).format(
                 os.path.join(
                     os.environ.get("XDG_CONFIG_HOME",
@@ -654,8 +652,7 @@ class GradienceApplication(Adw.Application):
             if len(preset_entry.get_text()) == 0:
                 dialog.set_body(
                     _(
-                        "Saving preset to <tt>{0}</tt>. If that preset \
-						already exists, it will be overwritten!"
+                        "Saving preset to <tt>{0}</tt>. If that preset already exists, it will be overwritten!"
                     ).format(
                         os.path.join(
                             os.environ.get(
@@ -671,8 +668,7 @@ class GradienceApplication(Adw.Application):
             else:
                 dialog.set_body(
                     _(
-                        "Saving preset to <tt>{0}</tt>. If that preset \
-						already exists, it will be overwritten!"
+                        "Saving preset to <tt>{0}</tt>. If that preset already exists, it will be overwritten!"
                     ).format(
                         os.path.join(
                             os.environ.get(
@@ -699,8 +695,7 @@ class GradienceApplication(Adw.Application):
             transient_for=self.props.active_window,
             heading=_("You have unsaved changes!"),
             body=_(
-                "Saving preset to <tt>{0}</tt>. If that preset already \
-				exists, it will be overwritten!"
+                "Saving preset to <tt>{0}</tt>. If that preset already exists, it will be overwritten!"
             ).format(
                 os.path.join(
                     os.environ.get("XDG_CONFIG_HOME",
@@ -730,8 +725,7 @@ class GradienceApplication(Adw.Application):
             if len(preset_entry.get_text()) == 0:
                 dialog.set_body(
                     _(
-                        "Saving preset to <tt>{0}</tt>. If that preset \
-						already exists, it will be overwritten!"
+                        "Saving preset to <tt>{0}</tt>. If that preset already exists, it will be overwritten!"
                     ).format(
                         os.path.join(
                             os.environ.get(
@@ -747,8 +741,7 @@ class GradienceApplication(Adw.Application):
             else:
                 dialog.set_body(
                     _(
-                        "Saving preset to <tt>{0}</tt>. If that preset \
-						already exists, it will be overwritten!"
+                        "Saving preset to <tt>{0}</tt>. If that preset already exists, it will be overwritten!"
                     ).format(
                         os.path.join(
                             os.environ.get(
@@ -964,32 +957,26 @@ class GradienceApplication(Adw.Application):
             release_notes=_(
                 """
                 <ul>
-        		<li>Add AdwViewSwitcher in the header bar.</li>
-        		<li>Move CSS to the "Advanced" tab</li>
-        		<li>Move the rest to the "Colours" tab</li>
-        		<li>Add Monet tab which generates a theme from a background
-					</li>
-        		<li>Add disk saved and disk unsaved icon in the header bar</li>
-        		<li>Update about dialog</li>
-        		<li>Change license to GNU GPLv3</li>
-        		<li>Begin plugin support</li>
-        		<li>Move preset selector to a drop-down called palette (icon \
-					palette)</li>
-        		<li>Add ability to apply the theme onlyfor dark theme or oy \
-					for light theme</li>
-        		<li>Automaticly use Adwaita-dark preset if the user prefered \
-					scheme is dark.</li>
-        		<li>Added Flatpak CI build</li>
-        		<li>Added issue template for bug and feature request </li>
-        		<li>`Main` branch is now protected by GitHub branch \
-					protection. The development is done on `next` branch </li>
-        		</ul>
-            	"""
+        <li>Add AdwViewSwitcher in the header bar.</li>
+        <li>Move CSS to the "Advanced" tab</li>
+        <li>Move the rest to the "Colours" tab</li>
+        <li>Add Monet tab which generates a theme from a background</li>
+        <li>Add disk saved and disk unsaved icon in the header bar</li>
+        <li>Update about dialog</li>
+        <li>Change license to GNU GPLv3</li>
+        <li>Begin plugin support</li>
+        <li>Move preset selector to a drop-down called palette (icon palette)</li>
+        <li>Add ability to apply the theme onlyfor dark theme or oy for light theme</li>
+        <li>Automaticly use Adwaita-dark preset if the user prefered scheme is dark.</li>
+        <li>Added Flatpak CI build</li>
+        <li>Added issue template for bug and feature request </li>
+        <li>`Main` branch is now protected by GitHub branch protection. The development is done on `next` branch </li>
+      </ul>
+            """
             ),
             comments=_(
                 """
-Gradience is a tool for customizing Libadwaita applications and the adw-gtk3 \
-theme.
+Gradience is a tool for customizing Libadwaita applications and the adw-gtk3 theme.
 With Gradience you can:
 
 - Change any color of Adwaita theme

--- a/gradience/option.py
+++ b/gradience/option.py
@@ -46,10 +46,7 @@ class GradienceOption(Adw.ActionRow):
         elif adw_gtk3_support == "partial":
             self.warning_button.add_css_class("warning")
             self.warning_label.set_label(
-                _(
-                    "This option is only partially supported by the adw-gtk3 \
-					theme."
-                )
+                _("This option is only partially supported by the adw-gtk3 theme.")
             )
         elif adw_gtk3_support == "no":
             self.warning_button.add_css_class("error")

--- a/gradience/plugins_list.py
+++ b/gradience/plugins_list.py
@@ -95,8 +95,7 @@ class GradiencePluginsList:
         group.set_title(_("Plugins"))
         group.set_description(
             _(
-                "Plugins add additional features to Gradience, plugins are \
-				made by Gradience community and can make issues."
+                "Plugins add additional features to Gradience, plugins are made by Gradience community and can make issues."
             )
         )
         empty = True

--- a/gradience/preset_row.py
+++ b/gradience/preset_row.py
@@ -117,8 +117,7 @@ class GradiencePresetRow(Adw.ExpanderRow):
         self.delete_toast = Adw.Toast(title=_("Preset removed"))
         self.delete_toast.set_button_label(_("Undo"))
         self.delete_toast.connect("dismissed", self.on_delete_toast_dismissed)
-        self.delete_toast.connect(
-            "button-clicked", self.on_undo_button_clicked)
+        self.delete_toast.connect("button-clicked", self.on_undo_button_clicked)
 
         self.toast_overlay.add_toast(self.delete_toast)
 

--- a/gradience/presets_manager_window.py
+++ b/gradience/presets_manager_window.py
@@ -65,9 +65,7 @@ class GradiencePresetWindow(Adw.Window):
         _(
             "Official"
         ): "https://github.com/GradienceTeam/Community/raw/next/official.json",
-        _(
-            "Curated"
-        ): "https://github.com/GradienceTeam/Community/raw/next/curated.json",
+        _("Curated"): "https://github.com/GradienceTeam/Community/raw/next/curated.json"
     }
 
     search_results_list = []
@@ -293,12 +291,7 @@ class GradiencePresetWindow(Adw.Window):
                         Adw.Toast(title=_("Preset imported")))
             else:
                 self.toast_overlay.add_toast(
-                    Adw.Toast(
-                        title=_(
-                            "Unsupported file format, must be \
-						.json"
-                        )
-                    )
+                    Adw.Toast(title=_("Unsupported file format, must be .json"))
                 )
 
         self.reload_pref_group()
@@ -387,9 +380,7 @@ class GradiencePresetWindow(Adw.Window):
         self.preset_list.set_title(_("User Presets"))
         self.preset_list.set_description(
             _(
-                'See \
-				<a href="https://github.com/GradienceTeam/Community">GradienceTeam/Community</a> \
-				on Github for more presets'
+                'See <a href="https://github.com/GradienceTeam/Community">GradienceTeam/Community</a> on Github for more presets'
             )
         )
 
@@ -414,8 +405,7 @@ class GradiencePresetWindow(Adw.Window):
             self.preset_empty = Adw.ActionRow()
             self.preset_empty.set_title(
                 _(
-                    "No preset found! Use the import button to import one or \
-					search one on the Explore tab"
+                    "No preset found! Use the import button to import one or search one on the Explore tab"
                 )
             )
             self.preset_list.add(self.preset_empty)

--- a/gradience/settings_schema.py
+++ b/gradience/settings_schema.py
@@ -22,19 +22,14 @@ settings_schema = {
             "name": "accent_colors",
             "title": _("Accent Colors"),
             "description": _(
-                "These colors are used across many different widgets, such as \
-				buttons, labels, and entries, to indicate that a widget is \
-				important, interactive, or currently active."
+                "These colors are used across many different widgets, such as buttons, labels, and entries, to indicate that a widget is important, interactive, or currently active."
             ),
             "variables": [
                 {
                     "name": "accent_color",
                     "title": _("Standalone Color"),
                     "explanation": _(
-                        "The standalone colors are similar to the background \
-						ones, but provide better contrast when used as \
-						foreground color on top of a neutral background - for \
-						example, colorful text in a window."
+                        "The standalone colors are similar to the background ones, but provide better contrast when used as foreground color on top of a neutral background - for example, colorful text in a window."
                     ),
                     "adw_gtk3_support": "yes",
                 },
@@ -54,18 +49,14 @@ settings_schema = {
             "name": "destructive_colors",
             "title": _("Destructive Colors"),
             "description": _(
-                "These colors are used for buttons to indicate a dangerous \
-				action, such as deleting a file."
+                "These colors are used for buttons to indicate a dangerous action, such as deleting a file."
             ),
             "variables": [
                 {
                     "name": "destructive_color",
                     "title": _("Standalone Color"),
                     "explanation": _(
-                        "The standalone colors are similar to the background \
-						ones, but provide better contrast when used as \
-						foreground color on top of a neutral background - for \
-						example, colorful text in a window."
+                        "The standalone colors are similar to the background ones, but provide better contrast when used as foreground color on top of a neutral background - for example, colorful text in a window."
                     ),
                     "adw_gtk3_support": "yes",
                 },
@@ -85,19 +76,14 @@ settings_schema = {
             "name": "success_colors",
             "title": _("Success Colors"),
             "description": _(
-                "These colors are used across many different widgets, such as \
-				buttons, labels, entries, and level bars, to indicate a \
-				success or a high level."
+                "These colors are used across many different widgets, such as buttons, labels, entries, and level bars, to indicate a success or a high level."
             ),
             "variables": [
                 {
                     "name": "success_color",
                     "title": _("Standalone Color"),
                     "explanation": _(
-                        "The standalone colors are similar to the background \
-						ones, but provide better contrast when used as \
-						foreground color on top of a neutral background - for \
-						example, colorful text in a window."
+                        "The standalone colors are similar to the background ones, but provide better contrast when used as foreground color on top of a neutral background - for example, colorful text in a window."
                     ),
                     "adw_gtk3_support": "yes",
                 },
@@ -117,19 +103,14 @@ settings_schema = {
             "name": "warning_colors",
             "title": _("Warning Colors"),
             "description": _(
-                "These colors are used across many different widgets, such as \
-				buttons, labels, entries, and level bars, to indicate a \
-				warning or a low level."
+                "These colors are used across many different widgets, such as buttons, labels, entries, and level bars, to indicate a warning or a low level."
             ),
             "variables": [
                 {
                     "name": "warning_color",
                     "title": _("Standalone Color"),
                     "explanation": _(
-                        "The standalone colors are similar to the background \
-						ones, but provide better contrast when used as \
-						foreground color on top of a neutral background - for \
-						example, colorful text in a window."
+                        "The standalone colors are similar to the background ones, but provide better contrast when used as foreground color on top of a neutral background - for example, colorful text in a window."
                     ),
                     "adw_gtk3_support": "yes",
                 },
@@ -149,18 +130,14 @@ settings_schema = {
             "name": "error_colors",
             "title": _("Error Colors"),
             "description": _(
-                "These colors are used across many different widgets, such as \
-				buttons, labels, and entries, to indicate a failure."
+                "These colors are used across many different widgets, such as buttons, labels, and entries, to indicate a failure."
             ),
             "variables": [
                 {
                     "name": "error_color",
                     "title": _("Standalone Color"),
                     "explanation": _(
-                        "The standalone colors are similar to the background \
-						ones, but provide better contrast when used as \
-						foreground color on top of a neutral background - for \
-						example, colorful text in a window."
+                        "The standalone colors are similar to the background ones, but provide better contrast when used as foreground color on top of a neutral background - for example, colorful text in a window."
                     ),
                     "adw_gtk3_support": "yes",
                 },
@@ -197,8 +174,7 @@ settings_schema = {
             "name": "view_colors",
             "title": _("View Colors"),
             "description": _(
-                "These colors are used in a variety of widgets, such as text \
-				views and entries."
+                "These colors are used in a variety of widgets, such as text views and entries."
             ),
             "variables": [
                 {
@@ -217,9 +193,7 @@ settings_schema = {
             "name": "headerbar_colors",
             "title": _("Header Bar Colors"),
             "description": _(
-                "These colors are used for header bars, as well as widgets \
-				that are meant to be visually attached to it, such as search \
-				bars or tab bars."
+                "These colors are used for header bars, as well as widgets that are meant to be visually attached to it, such as search bars or tab bars."
             ),
             "variables": [
                 {
@@ -236,14 +210,7 @@ settings_schema = {
                     "name": "headerbar_border_color",
                     "title": _("Border Color"),
                     "explanation": _(
-                        "The border color has the same default value as a \
-						foreground color, but doesn't change along with it. \
-						This can be useful if a light window has a dark \
-						header bar with light text; in this case it may be \
-						desirable to keep the border dark. This variable is \
-						only used for vertical borders - for example, \
-						separators between the two header bars in a split \
-						header bar layout."
+                        "The border color has the same default value as a foreground color, but doesn't change along with it. This can be useful if a light window has a dark header bar with light text; in this case it may be desirable to keep the border dark. This variable is only used for vertical borders - for example, separators between the two header bars in a split header bar layout."
                     ),
                     "adw_gtk3_support": "no",
                 },
@@ -251,12 +218,7 @@ settings_schema = {
                     "name": "headerbar_backdrop_color",
                     "title": _("Backdrop Color"),
                     "explanation": _(
-                        "The backdrop color is used instead of the background \
-						color when the window is not focused. By default it's \
-						an alias of the window's background color and changes \
-						together with it. When changing this variable, make \
-						sure to set it to a value matching your header bar \
-						background color."
+                        "The backdrop color is used instead of the background color when the window is not focused. By default it's an alias of the window's background color and changes together with it. When changing this variable, make sure to set it to a value matching your header bar background color."
                     ),
                     "adw_gtk3_support": "yes",
                 },
@@ -264,9 +226,7 @@ settings_schema = {
                     "name": "headerbar_shade_color",
                     "title": _("Shade Color"),
                     "explanation": _(
-                        "The shade color is used to provide a dark border for \
-						header bars and similar widgets that separates them \
-						from the main window."
+                        "The shade color is used to provide a dark border for header bars and similar widgets that separates them from the main window."
                     ),
                     "adw_gtk3_support": "no",
                 },
@@ -275,10 +235,7 @@ settings_schema = {
         {
             "name": "card_colors",
             "title": _("Card Colors"),
-            "description": _(
-                "These colors are used for cards and boxed \
-				lists."
-            ),
+            "description": _("These colors are used for cards and boxed lists."),
             "variables": [
                 {
                     "name": "card_bg_color",
@@ -294,9 +251,7 @@ settings_schema = {
                     "name": "card_shade_color",
                     "title": _("Shade Color"),
                     "explanation": _(
-                        "The shade color is used for shadows that are used by \
-						cards to separate themselves from the window \
-						background, as well as for row dividers in the cards."
+                        "The shade color is used for shadows that are used by cards to separate themselves from the window background, as well as for row dividers in the cards."
                     ),
                     "adw_gtk3_support": "no",
                 },
@@ -345,9 +300,7 @@ settings_schema = {
                     "name": "shade_color",
                     "title": _("Shade Color"),
                     "explanation": _(
-                        "The shade color is used by inline tab bars, as well \
-						as the transitions in leaflets and flaps, and info \
-						bar borders."
+                        "The shade color is used by inline tab bars, as well as the transitions in leaflets and flaps, and info bar borders."
                     ),
                     "adw_gtk3_support": "no",
                 },
@@ -355,9 +308,7 @@ settings_schema = {
                     "name": "scrollbar_outline_color",
                     "title": _("Scrollbar Outline Color"),
                     "explanation": _(
-                        "The scrollbar outline color is used by scrollbars to \
-						ensure that overlay scrollbars are visible regardless \
-						of the content color."
+                        "The scrollbar outline color is used by scrollbars to ensure that overlay scrollbars are visible regardless of the content color."
                     ),
                     "adw_gtk3_support": "no",
                 },

--- a/gradience/welcome.py
+++ b/gradience/welcome.py
@@ -142,9 +142,7 @@ class GradienceWelcomeWindow(Adw.Window):
         self.btn_next.set_visible(True)
         self.btn_install.set_visible(False)
         if self.update:
-            self.window.last_opened_version = self.window.settings.set_string(
-                "last-opened-version", version
-            )
+            self.window.last_opened_version = self.window.settings.set_string("last-opened-version", version)
             self.btn_close.set_sensitive(True)
             self.label_skip.set_visible(False)
             self.next_page(index=5)

--- a/gradience/window.py
+++ b/gradience/window.py
@@ -132,8 +132,7 @@ class GradienceMainWindow(Adw.ApplicationWindow):
         self.monet_pref_group.set_title(_("Monet Engine"))
         self.monet_pref_group.set_description(
             _(
-                "Monet is an engine that generates a Material Design 3 \
-				palette from an image's color."
+                "Monet is an engine that generates a Material Design 3 palette from an image's color."
             )
         )
 
@@ -269,10 +268,7 @@ class GradienceMainWindow(Adw.ApplicationWindow):
         palette_pref_group.set_title(_("Palette Colors"))
         palette_pref_group.set_description(
             _(
-                'Named palette colors used by some applications. Default \
-				colors follow the \
-				<a href="https://developer.gnome.org/hig/reference/palette.html">\
-					GNOME Human Interface Guidelines</a>.'
+                'Named palette colors used by some applications. Default colors follow the <a href="https://developer.gnome.org/hig/reference/palette.html">GNOME Human Interface Guidelines</a>.'
             )
         )
         for color in settings_schema["palette"]:


### PR DESCRIPTION
This reverts a PR #476, which (as a side effect of making everything max 79 lines long) created spaces between words in most translatable strings.

Screenshots of a bug:
![Screenshot from 2022-09-23 18-37-32](https://user-images.githubusercontent.com/73042332/192011690-c299b5b3-b0cd-4030-8874-2be1ed15bc01.png)
![Screenshot from 2022-09-23 18-48-56](https://user-images.githubusercontent.com/73042332/192011997-f9a5eef9-6b77-40f6-8954-9f8b102f4e7a.png)
In my opinion, we shouldn't make such commits, as we have code formatting handled by a `black` and `autopep8` linters.

There are only 8 revert commits, opposed to 12 in original pull request, as #479 restored some of the code to be compliant with `black` and `autopep8` linters.