### PR TITLE
Sync upstream manifests with Flathub manifests

### DIFF
--- a/build-aux/flatpak/com.github.GradienceTeam.Gradience.Devel.json
+++ b/build-aux/flatpak/com.github.GradienceTeam.Gradience.Devel.json
@@ -13,7 +13,8 @@
         "--socket=session-bus",
         "--filesystem=xdg-data/flatpak/overrides:create",
         "--filesystem=xdg-config/gtk-3.0",
-        "--filesystem=xdg-config/gtk-4.0"
+        "--filesystem=xdg-config/gtk-4.0",
+        "--filesystem=xdg-run/gvfsd"
     ],
     "cleanup" : [
         "/include",

--- a/build-aux/flatpak/com.github.GradienceTeam.Gradience.Devel.json
+++ b/build-aux/flatpak/com.github.GradienceTeam.Gradience.Devel.json
@@ -55,36 +55,44 @@
             ]
         },
         {
-            "name": "libsass",
-            "buildsystem": "simple",
-            "build-commands": [
-                "autoreconf --force --install",
-                "./configure --enable-shared --prefix=/app",
-                "make -j4",
-                "make install"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/sass/libsass.git",
-                    "tag": "3.6.5"
-                }
-            ]
-        },
-        {
             "name": "sassc",
-            "buildsystem": "simple",
-            "build-commands": [
-                "autoreconf --force --install",
-                "./configure --prefix=/app",
-                "make -j4",
-                "make install"
-            ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/sass/sassc.git",
                     "tag": "3.6.2"
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "autogen.sh",
+                    "commands": [
+                        "autoreconf -si"
+                    ]
+                }
+            ],
+            "cleanup": [
+                "*"
+            ],
+            "modules": [
+                {
+                    "name": "libsass",
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/sass/libsass.git",
+                            "tag": "3.6.5"
+                        },
+                        {
+                            "type": "script",
+                            "dest-filename": "autogen.sh",
+                            "commands": [
+                                "autoreconf -si"
+                            ]
+                        }
+                    ],
+                    "cleanup": [
+                        "*"
+                    ]
                 }
             ]
         },
@@ -118,8 +126,5 @@
                 }
             ]
         }
-    ],
-    "build-options" : {
-        "env" : {        }
-    }
+    ]
 }

--- a/build-aux/flatpak/com.github.GradienceTeam.Gradience.json
+++ b/build-aux/flatpak/com.github.GradienceTeam.Gradience.json
@@ -13,7 +13,8 @@
         "--socket=session-bus",
         "--filesystem=xdg-data/flatpak/overrides:create",
         "--filesystem=xdg-config/gtk-3.0",
-        "--filesystem=xdg-config/gtk-4.0"
+        "--filesystem=xdg-config/gtk-4.0",
+        "--filesystem=xdg-run/gvfsd"
     ],
     "cleanup" : [
         "/include",

--- a/build-aux/flatpak/com.github.GradienceTeam.Gradience.json
+++ b/build-aux/flatpak/com.github.GradienceTeam.Gradience.json
@@ -50,41 +50,49 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "branch" : "v0.4.0"
-                }
-            ]
-        },
-        {
-            "name": "libsass",
-            "buildsystem": "simple",
-            "build-commands": [
-                "autoreconf --force --install",
-                "./configure --enable-shared --prefix=/app",
-                "make -j4",
-                "make install"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/sass/libsass.git",
-                    "tag": "3.6.5"
+                    "tag" : "v0.4.0"
                 }
             ]
         },
         {
             "name": "sassc",
-            "buildsystem": "simple",
-            "build-commands": [
-                "autoreconf --force --install",
-                "./configure --prefix=/app",
-                "make -j4",
-                "make install"
-            ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/sass/sassc.git",
                     "tag": "3.6.2"
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "autogen.sh",
+                    "commands": [
+                        "autoreconf -si"
+                    ]
+                }
+            ],
+            "cleanup": [
+                "*"
+            ],
+            "modules": [
+                {
+                    "name": "libsass",
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/sass/libsass.git",
+                            "tag": "3.6.5"
+                        },
+                        {
+                            "type": "script",
+                            "dest-filename": "autogen.sh",
+                            "commands": [
+                                "autoreconf -si"
+                            ]
+                        }
+                    ],
+                    "cleanup": [
+                        "*"
+                    ]
                 }
             ]
         },
@@ -118,8 +126,5 @@
                 }
             ]
         }
-    ],
-    "build-options" : {
-        "env" : {        }
-    }
+    ]
 }


### PR DESCRIPTION
This PR makes a couple of corrections into upstream Flatpak manifests to make them more Flathub compliant (less work for Flathub packages maintainer and improved compile performance), ~~and adds a fix for issue #612~~ (added in a8a1df74b2a283446869a31338b9d6be6bdf0a30).