### PR TITLE
Firefox theme plugin:  correctly parse installations with multipe profiles

### DIFF
--- a/data/plugins/firefox_gnome_theme.py
+++ b/data/plugins/firefox_gnome_theme.py
@@ -118,11 +118,11 @@ class FirefoxGnomeTheme2Plugin(IPlugin):
                      "~/.var/app/org.mozilla.firefox/.mozilla/firefox",
                      "~/.var/app/io.gitlab.librewolf-community/.librewolf"]:
             try:
-                with (
-                    next(Path("firefox").expanduser().glob("*.*"))
-                    / "chrome/firefox-gnome-theme/customChrome.css"
-                ).open("w") as f:
-                    f.write(self.template.format(**self.variables))
+                for result in Path(path).expanduser().glob("*.*"):
+                    if Path.is_dir(result):
+                        with open(f"{result}/chrome/firefox-gnome-theme/customChrome.css","w") as f:
+                            print(result)
+                            f.write(self.template.format(**self.variables))
             except OSError:
                 pass
             except StopIteration:

--- a/data/plugins/firefox_gnome_theme.py
+++ b/data/plugins/firefox_gnome_theme.py
@@ -121,7 +121,6 @@ class FirefoxGnomeTheme2Plugin(IPlugin):
                 for result in Path(path).expanduser().glob("*.*"):
                     if Path.is_dir(result):
                         with open(f"{result}/chrome/firefox-gnome-theme/customChrome.css","w") as f:
-                            print(result)
                             f.write(self.template.format(**self.variables))
             except OSError:
                 pass


### PR DESCRIPTION
# Allows theming firefox/librefox installations with multiple profiles

The old code would incorrectly iterate over files (such as the profiles.ini file) which would trigger an exception and skip the entire firefox installation.  This checks the path to ensure it is a directory (and thus a profile) before trying to open the customChrome.css file for writing.  It correctly themes my Librefox now.

## Changelog

- Fixed path iteration