### PR TITLE
feat: remove libportal

### DIFF
--- a/build-aux/flatpak/com.github.GradienceTeam.Gradience.Devel.json
+++ b/build-aux/flatpak/com.github.GradienceTeam.Gradience.Devel.json
@@ -102,22 +102,6 @@
             ]
         },
         {
-            "name": "libportal",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Ddocs=false",
-                "-Dvapi=false",
-                "-Dbackends=gtk4"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/flatpak/libportal",
-                    "tag": "main"
-                }
-            ]
-        },
-        {
             "name" : "gradience",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/build-aux/flatpak/com.github.GradienceTeam.Gradience.json
+++ b/build-aux/flatpak/com.github.GradienceTeam.Gradience.json
@@ -102,22 +102,6 @@
             ]
         },
         {
-            "name": "libportal",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Ddocs=false",
-                "-Dvapi=false",
-                "-Dbackends=gtk4"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/flatpak/libportal",
-                    "tag": "0.6"
-                }
-            ]
-        },
-        {
             "name" : "gradience",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ dependency('gtk4', version: '>= 4.5.0')
 dependency('libadwaita-1', version: '>= 1.2.alpha')
 dependency('pygobject-3.0', version: '>= 3.42.0')
 dependency('libsoup-3.0', version: '>= 3.2.0')
+dependency('libportal-gtk4', version: '>= 0.6')
 
 # Python installation directory
 PY_INSTALLDIR = python.find_installation('python3', required: true, modules: ['lxml'])


### PR DESCRIPTION
# Remove `libportal` from build

libportal not needed anymore as GNOME Runtime 43 already include include it

## Changelog

- Removed `libportal`