### PR TITLE
Use hexadecimal format unless alpha channel is specified

### DIFF
--- a/gradience/backend/theming/preset_utils.py
+++ b/gradience/backend/theming/preset_utils.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from gi.repository import GLib, Gio
 
 from gradience.backend.models.preset import Preset
-from gradience.backend.utils.colors import rgba_from_argb
+from gradience.backend.utils.colors import argb_to_color_code
 
 from gradience.backend.globals import presets_dir, get_gtk_theme_dir
 
@@ -68,98 +68,98 @@ class PresetUtils:
         if theme == "dark":
             dark_theme = monet_palette["schemes"]["dark"]
             variable = {
-                "accent_color": rgba_from_argb(dark_theme.primary),
-                "accent_bg_color": rgba_from_argb(dark_theme.primaryContainer),
-                "accent_fg_color": rgba_from_argb(dark_theme.onPrimaryContainer),
-                "destructive_color": rgba_from_argb(dark_theme.error),
-                "destructive_bg_color": rgba_from_argb(dark_theme.errorContainer),
-                "destructive_fg_color": rgba_from_argb(
+                "accent_color": argb_to_color_code(dark_theme.primary),
+                "accent_bg_color": argb_to_color_code(dark_theme.primaryContainer),
+                "accent_fg_color": argb_to_color_code(dark_theme.onPrimaryContainer),
+                "destructive_color": argb_to_color_code(dark_theme.error),
+                "destructive_bg_color": argb_to_color_code(dark_theme.errorContainer),
+                "destructive_fg_color": argb_to_color_code(
                     dark_theme.onErrorContainer
                 ),
-                "success_color": rgba_from_argb(dark_theme.tertiary),
-                "success_bg_color": rgba_from_argb(dark_theme.onTertiary),
-                "success_fg_color": rgba_from_argb(dark_theme.onTertiaryContainer),
-                "warning_color": rgba_from_argb(dark_theme.secondary),
-                "warning_bg_color": rgba_from_argb(dark_theme.onSecondary),
-                "warning_fg_color": rgba_from_argb(dark_theme.primary, "0.8"),
-                "error_color": rgba_from_argb(dark_theme.error),
-                "error_bg_color": rgba_from_argb(dark_theme.errorContainer),
-                "error_fg_color": rgba_from_argb(dark_theme.onError),
-                "window_bg_color": rgba_from_argb(dark_theme.surface),
-                "window_fg_color": rgba_from_argb(dark_theme.onSurface),
-                "view_bg_color": rgba_from_argb(dark_theme.surface),
-                "view_fg_color": rgba_from_argb(dark_theme.onSurface),
-                "headerbar_bg_color": rgba_from_argb(dark_theme.surface),
-                "headerbar_fg_color": rgba_from_argb(dark_theme.onSurface),
-                "headerbar_border_color": rgba_from_argb(
+                "success_color": argb_to_color_code(dark_theme.tertiary),
+                "success_bg_color": argb_to_color_code(dark_theme.onTertiary),
+                "success_fg_color": argb_to_color_code(dark_theme.onTertiaryContainer),
+                "warning_color": argb_to_color_code(dark_theme.secondary),
+                "warning_bg_color": argb_to_color_code(dark_theme.onSecondary),
+                "warning_fg_color": argb_to_color_code(dark_theme.primary, "0.8"),
+                "error_color": argb_to_color_code(dark_theme.error),
+                "error_bg_color": argb_to_color_code(dark_theme.errorContainer),
+                "error_fg_color": argb_to_color_code(dark_theme.onError),
+                "window_bg_color": argb_to_color_code(dark_theme.surface),
+                "window_fg_color": argb_to_color_code(dark_theme.onSurface),
+                "view_bg_color": argb_to_color_code(dark_theme.surface),
+                "view_fg_color": argb_to_color_code(dark_theme.onSurface),
+                "headerbar_bg_color": argb_to_color_code(dark_theme.surface),
+                "headerbar_fg_color": argb_to_color_code(dark_theme.onSurface),
+                "headerbar_border_color": argb_to_color_code(
                     dark_theme.primary, "0.8"
                 ),
                 "headerbar_backdrop_color": "@headerbar_bg_color",
-                "headerbar_shade_color": rgba_from_argb(dark_theme.shadow),
-                "card_bg_color": rgba_from_argb(dark_theme.primary, "0.05"),
-                "card_fg_color": rgba_from_argb(dark_theme.onSecondaryContainer),
-                "card_shade_color": rgba_from_argb(dark_theme.shadow),
-                "dialog_bg_color": rgba_from_argb(dark_theme.secondaryContainer),
-                "dialog_fg_color": rgba_from_argb(dark_theme.onSecondaryContainer),
-                "popover_bg_color": rgba_from_argb(dark_theme.secondaryContainer),
-                "popover_fg_color": rgba_from_argb(
+                "headerbar_shade_color": argb_to_color_code(dark_theme.shadow),
+                "card_bg_color": argb_to_color_code(dark_theme.primary, "0.05"),
+                "card_fg_color": argb_to_color_code(dark_theme.onSecondaryContainer),
+                "card_shade_color": argb_to_color_code(dark_theme.shadow),
+                "dialog_bg_color": argb_to_color_code(dark_theme.secondaryContainer),
+                "dialog_fg_color": argb_to_color_code(dark_theme.onSecondaryContainer),
+                "popover_bg_color": argb_to_color_code(dark_theme.secondaryContainer),
+                "popover_fg_color": argb_to_color_code(
                     dark_theme.onSecondaryContainer
                 ),
-                "shade_color": rgba_from_argb(dark_theme.shadow),
-                "scrollbar_outline_color": rgba_from_argb(dark_theme.outline),
+                "shade_color": argb_to_color_code(dark_theme.shadow),
+                "scrollbar_outline_color": argb_to_color_code(dark_theme.outline),
             }
         elif theme == "light":
             light_theme = monet_palette["schemes"]["light"]
             variable = {
-                "accent_color": rgba_from_argb(light_theme.primary),
-                "accent_bg_color": rgba_from_argb(light_theme.primary),
-                "accent_fg_color": rgba_from_argb(light_theme.onPrimary),
-                "destructive_color": rgba_from_argb(light_theme.error),
-                "destructive_bg_color": rgba_from_argb(light_theme.errorContainer),
-                "destructive_fg_color": rgba_from_argb(
+                "accent_color": argb_to_color_code(light_theme.primary),
+                "accent_bg_color": argb_to_color_code(light_theme.primary),
+                "accent_fg_color": argb_to_color_code(light_theme.onPrimary),
+                "destructive_color": argb_to_color_code(light_theme.error),
+                "destructive_bg_color": argb_to_color_code(light_theme.errorContainer),
+                "destructive_fg_color": argb_to_color_code(
                     light_theme.onErrorContainer
                 ),
-                "success_color": rgba_from_argb(light_theme.tertiary),
-                "success_bg_color": rgba_from_argb(light_theme.tertiaryContainer),
-                "success_fg_color": rgba_from_argb(
+                "success_color": argb_to_color_code(light_theme.tertiary),
+                "success_bg_color": argb_to_color_code(light_theme.tertiaryContainer),
+                "success_fg_color": argb_to_color_code(
                     light_theme.onTertiaryContainer
                 ),
-                "warning_color": rgba_from_argb(light_theme.secondary),
-                "warning_bg_color": rgba_from_argb(light_theme.secondaryContainer),
-                "warning_fg_color": rgba_from_argb(
+                "warning_color": argb_to_color_code(light_theme.secondary),
+                "warning_bg_color": argb_to_color_code(light_theme.secondaryContainer),
+                "warning_fg_color": argb_to_color_code(
                     light_theme.onSecondaryContainer
                 ),
-                "error_color": rgba_from_argb(light_theme.error),
-                "error_bg_color": rgba_from_argb(light_theme.errorContainer),
-                "error_fg_color": rgba_from_argb(light_theme.onError),
-                "window_bg_color": rgba_from_argb(light_theme.secondaryContainer),
-                "window_fg_color": rgba_from_argb(light_theme.onSurface),
-                "view_bg_color": rgba_from_argb(light_theme.secondaryContainer),
-                "view_fg_color": rgba_from_argb(light_theme.onSurface),
-                "headerbar_bg_color": rgba_from_argb(
+                "error_color": argb_to_color_code(light_theme.error),
+                "error_bg_color": argb_to_color_code(light_theme.errorContainer),
+                "error_fg_color": argb_to_color_code(light_theme.onError),
+                "window_bg_color": argb_to_color_code(light_theme.secondaryContainer),
+                "window_fg_color": argb_to_color_code(light_theme.onSurface),
+                "view_bg_color": argb_to_color_code(light_theme.secondaryContainer),
+                "view_fg_color": argb_to_color_code(light_theme.onSurface),
+                "headerbar_bg_color": argb_to_color_code(
                     light_theme.secondaryContainer
                 ),
-                "headerbar_fg_color": rgba_from_argb(light_theme.onSurface),
-                "headerbar_border_color": rgba_from_argb(
+                "headerbar_fg_color": argb_to_color_code(light_theme.onSurface),
+                "headerbar_border_color": argb_to_color_code(
                     light_theme.primary, "0.8"
                 ),
                 "headerbar_backdrop_color": "@headerbar_bg_color",
-                "headerbar_shade_color": rgba_from_argb(
+                "headerbar_shade_color": argb_to_color_code(
                     light_theme.secondaryContainer
                 ),
-                "card_bg_color": rgba_from_argb(light_theme.primary, "0.05"),
-                "card_fg_color": rgba_from_argb(light_theme.onSecondaryContainer),
-                "card_shade_color": rgba_from_argb(light_theme.shadow),
-                "dialog_bg_color": rgba_from_argb(light_theme.secondaryContainer),
-                "dialog_fg_color": rgba_from_argb(
+                "card_bg_color": argb_to_color_code(light_theme.primary, "0.05"),
+                "card_fg_color": argb_to_color_code(light_theme.onSecondaryContainer),
+                "card_shade_color": argb_to_color_code(light_theme.shadow),
+                "dialog_bg_color": argb_to_color_code(light_theme.secondaryContainer),
+                "dialog_fg_color": argb_to_color_code(
                     light_theme.onSecondaryContainer
                 ),
-                "popover_bg_color": rgba_from_argb(light_theme.secondaryContainer),
-                "popover_fg_color": rgba_from_argb(
+                "popover_bg_color": argb_to_color_code(light_theme.secondaryContainer),
+                "popover_fg_color": argb_to_color_code(
                     light_theme.onSecondaryContainer
                 ),
-                "shade_color": rgba_from_argb(light_theme.shadow),
-                "scrollbar_outline_color": rgba_from_argb(light_theme.outline),
+                "shade_color": argb_to_color_code(light_theme.shadow),
+                "scrollbar_outline_color": argb_to_color_code(light_theme.outline),
             }
 
         if obj_only == False and not name:

--- a/gradience/backend/utils/colors.py
+++ b/gradience/backend/utils/colors.py
@@ -30,6 +30,38 @@ def rgba_from_argb(argb, alpha=None) -> str:
 
     return base.format(red, green, blue, alpha)
 
+def rgb_to_hash(rgb) -> [str, float]:
+    """
+    This function converts rgb or rgba-formatted color code to an hexadecimal code.
+
+    Alpha channel from RGBA color codes is passed without any convertion
+    as a second return variable and is completely ignored in hexadecimal codes
+    to remain compliant with web stantards.
+    """
+    if rgb.startswith("rgb"):
+        rgb_values = rgb.strip("rgb()")
+
+    if rgb.startswith("rgba"):
+        rgb_values = rgb.strip("rgba()")
+
+    rgb_list = rgb_values.split(",")
+
+    red = int(rgb_list[0])
+    green = int(rgb_list[1])
+    blue = int(rgb_list[2])
+    alpha = None
+
+    if len(rgb_list) == 4:
+        alpha = float(rgb_list[3])
+
+    hex_out = [f"{red:x}", f"{green:x}", f"{blue:x}"]
+
+    for i, hex_part in enumerate(hex_out):
+        if len(hex_part) == 1:
+            hex_out[i] = "0" + hex_part
+
+    return "#" + "".join(hex_out), alpha
+
 def argb_to_color_code(argb, alpha=None) -> str:
     """
     This function can return either an hexadecimal or rgba-formatted color code.
@@ -38,18 +70,15 @@ def argb_to_color_code(argb, alpha=None) -> str:
     If alpha parameter is specified, then the function will return
     an rgba-formatted color code.
     """
-    hex_base = "#{0:x}{1:x}{2:x}"
     rgba_base = "rgba({0}, {1}, {2}, {3})"
 
-    red_chnl = monet.redFromArgb(argb)
-    green_chnl = monet.greenFromArgb(argb)
-    blue_chnl = monet.blueFromArgb(argb)
-    alpha_chnl = alpha
-
+    red = monet.redFromArgb(argb)
+    green = monet.greenFromArgb(argb)
+    blue = monet.blueFromArgb(argb)
     if not alpha:
-        alpha_chnl = monet.alphaFromArgb(argb)
+        alpha = monet.alphaFromArgb(argb)
 
-    if alpha_chnl in (255, 0.0):
-        return hex_base.format(red_chnl, green_chnl, blue_chnl)
+    if alpha in (255, 0.0):
+        return monet.hexFromArgb(argb)
 
-    return rgba_base.format(red_chnl, green_chnl, blue_chnl, alpha_chnl)
+    return rgba_base.format(red, green, blue, alpha)


### PR DESCRIPTION
# Description

This PR enforces on Gradience usage of hexadecimal format in most places, unless alpha channel is specified.
The enforcement of hex format is only on Gradience itself, users still can use RGB and standard web CSS color names.

Probably Fixes #666 

## Type of change

<!-- What type of change does your pull request introduce? Put an `x` in the box that apply. -->
- [ ] Bugfix (Change which fixes a issue)
- [ ] New feature (Change which adds new functionality)
- [x] Enhancement (Change which slightly improves existing code)
- [ ] Breaking change (This change will introduce incompatibility with existing functionality)

## Changelog <!-- This is optional, but highly appreciated. -->

- Created new `rgb_to_hash` function,
- Made `argb_to_color_code` function usable,
- Enforced HEX format on Monet generated variables and ColorButtons in variables rows

## Testing

- [x] I have tested my changes and verified that they work as expected <!-- Required, your PR won't be accepted if you don't do this step. -->

### How to test the changes

<!-- Optional, it can speed up review process if you provide the information on how to test your changes. -->
No information provided.
