### PR TITLE
Show `Unsaved preset` dialog when switching to other preset

### DIFF
--- a/gradience/frontend/dialogs/save_dialog.py
+++ b/gradience/frontend/dialogs/save_dialog.py
@@ -21,6 +21,8 @@ from gi.repository import Gtk, Adw
 from gradience.backend.constants import rootdir
 
 
+# TODO: Make this dialog async when Libadwaita 1.3 becomes available \
+# https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/method.MessageDialog.choose.html
 @Gtk.Template(resource_path=f"{rootdir}/ui/save_dialog.ui")
 class GradienceSaveDialog(Adw.MessageDialog):
     __gtype_name__ = "GradienceSaveDialog"

--- a/gradience/frontend/widgets/preset_row.py
+++ b/gradience/frontend/widgets/preset_row.py
@@ -1,7 +1,7 @@
 # preset_row.py
 #
 # Change the look of Adwaita, with ease
-# Copyright (C) 2022  Gradience Team
+# Copyright (C) 2022-2023, Gradience Team
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -105,9 +105,28 @@ class GradiencePresetRow(Adw.ExpanderRow):
         self.win.app.save_favourite()
         self.win.reload_pref_group()
 
+    def show_unsaved_dialog(self, *_args):
+        dialog, preset_entry = self.app.construct_unsaved_dialog()
+
+        def on_unsaved_dialog_response(_widget, response, preset_entry):
+            if response == "save":
+                self.app.preset.save_to_file(preset_entry.get_text(), self.app.plugins_list)
+                self.app.clear_dirty()
+                self.app.load_preset_from_file(self.preset.preset_path)
+            elif response == "discard":
+                self.app.clear_dirty()
+                self.app.load_preset_from_file(self.preset.preset_path)
+
+        dialog.connect("response", on_unsaved_dialog_response, preset_entry)
+
+        dialog.present()
+
     @Gtk.Template.Callback()
     def on_apply_button_clicked(self, *_args):
-        self.app.load_preset_from_file(self.preset.preset_path)
+        if self.app.is_dirty:
+            self.show_unsaved_dialog()
+        else:
+            self.app.load_preset_from_file(self.preset.preset_path)
 
     def on_undo_button_clicked(self, *_args):
         self.delete_preset = False


### PR DESCRIPTION
# Description

This PR reuses `You have unsaved changes!` dialog when an currently preset isn't yet saved and user clicks to load another preset. The implementation uses internal `is_dirty` check to determine either to show or immediately load a preset.

Fixes #665

## Type of change

<!-- What type of change does your pull request introduce? Put an `x` in the box that apply. -->
- [ ] Bugfix (Change which fixes a issue)
- [ ] New feature (Change which adds new functionality)
- [x] Enhancement (Change which slightly improves existing code)
- [ ] Breaking change (This change will introduce incompatibility with existing functionality)

## Changelog <!-- This is optional, but highly appreciated. -->

- Extracted `show_unsaved_dialog` function into two smaller functions
- Made `on_save_preset_entry_change` function accessible in external modules
- Changed `save_preset` function name to `on_save_dialog_response`
- Added mechanisms to show unsaved dialog in Preset Manager and when using quick preset switcher

## Testing

- [x] I have tested my changes and verified that they work as expected <!-- Required, your PR won't be accepted if you don't do this step. -->

### How to test the changes

<!-- Optional, it can speed up review process if you provide the information on how to test your changes. -->
No information provided.
