### PR TITLE
feat: add mnemonics to view switchers

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -85,26 +85,29 @@ template GradienceMainWindow : Adw.ApplicationWindow {
 
             Adw.ViewStackPage {
               name: "colors";
-              title: _("Colors");
+              title: _("_Colors");
               icon-name: "larger-brush-symbolic";
 
               child: Adw.PreferencesPage content { };
+              use-underline: true;
             }
 
             Adw.ViewStackPage {
               name: "monet";
-              title: _("Monet");
+              title: _("_Monet");
               icon-name: "color-picker-symbolic";
 
               child: Adw.PreferencesPage content_monet { };
+              use-underline: true;
             }
 
             Adw.ViewStackPage {
               name: "plugins";
-              title: _("Advanced");
+              title: _("_Advanced");
               icon-name: "settings-symbolic";
 
               child: Adw.PreferencesPage content_plugins { };
+              use-underline: true;
             }
           }
 


### PR DESCRIPTION
## Description

I added mnemonics to the labels that switch pages: "Colors",
 "Monet" and "Advanced".
Still need to translate this feature to others languages
 and I'd be glad to do that to Brazilian Portuguese. :)

## Type of change

- [ ] Bugfix (Change which fixes a issue)
- [ ] New feature (Change which adds new functionality)
- [x] Enhancement (Change which slightly improves existing code)
- [ ] Breaking change (This change will introduce incompatibility with existing functionality)

## Changelog

- Added
    - mnemonics to labels in initial page: "Colors", "Monet" and "Advanced" 

## Testing

- [x] I have tested my changes and verified that they work as expected

### How to test the changes

To use this feature, you just need to press "alt" and it should highlight with an underline the options of mnemonics with shortcuts.
Than press the letter underlined in the option you choose to access.
