### PR TITLE
fix(preset_utils.py): Improve error/destructive contrasts

### DIFF
--- a/gradience/backend/theming/preset_utils.py
+++ b/gradience/backend/theming/preset_utils.py
@@ -73,7 +73,8 @@ class PresetUtils:
                 "accent_fg_color": argb_to_color_code(light_theme.onPrimary),
                 "destructive_color": argb_to_color_code(light_theme.error),
                 "destructive_bg_color": argb_to_color_code(light_theme.errorContainer),
-                "destructive_fg_color": argb_to_color_code(light_theme.onError),
+                # Do not touch! .onError causes contrast issues!
+                "destructive_fg_color": argb_to_color_code(light_theme.onErrorContainer),
                 "success_color": argb_to_color_code(light_theme.tertiary),
                 "success_bg_color": argb_to_color_code(light_theme.tertiaryContainer),
                 "success_fg_color": argb_to_color_code(light_theme.onTertiaryContainer),
@@ -82,7 +83,8 @@ class PresetUtils:
                 "warning_fg_color": argb_to_color_code(light_theme.onSecondaryContainer),
                 "error_color": argb_to_color_code(light_theme.error),
                 "error_bg_color": argb_to_color_code(light_theme.errorContainer),
-                "error_fg_color": argb_to_color_code(light_theme.onError),
+                # Do not touch
+                "error_fg_color": argb_to_color_code(light_theme.onErrorContainer),
                 "window_bg_color": argb_to_color_code(light_theme.surface),
                 "window_fg_color": argb_to_color_code(light_theme.onSurface),
                 "view_bg_color": argb_to_color_code(light_theme.secondaryContainer),
@@ -110,7 +112,8 @@ class PresetUtils:
                 "accent_fg_color": argb_to_color_code(dark_theme.onPrimary),
                 "destructive_color": argb_to_color_code(dark_theme.error),
                 "destructive_bg_color": argb_to_color_code(dark_theme.errorContainer),
-                "destructive_fg_color": argb_to_color_code(dark_theme.onError),
+                # No touchy
+                "destructive_fg_color": argb_to_color_code(dark_theme.onErrorContainer),
                 "success_color": argb_to_color_code(dark_theme.tertiary),
                 "success_bg_color": argb_to_color_code(dark_theme.tertiaryContainer),
                 "success_fg_color": argb_to_color_code(dark_theme.onTertiaryContainer),
@@ -119,7 +122,8 @@ class PresetUtils:
                 "warning_fg_color": argb_to_color_code(dark_theme.onSecondaryContainer),
                 "error_color": argb_to_color_code(dark_theme.error),
                 "error_bg_color": argb_to_color_code(dark_theme.errorContainer),
-                "error_fg_color": argb_to_color_code(dark_theme.onError),
+                # Do not use .onError plz
+                "error_fg_color": argb_to_color_code(dark_theme.onErrorContainer),
                 "window_bg_color": argb_to_color_code(dark_theme.surface),
                 "window_fg_color": argb_to_color_code(dark_theme.onSurface),
                 "view_bg_color": argb_to_color_code(dark_theme.secondaryContainer),


### PR DESCRIPTION
## Description

Changed .onError to .onErrorContainer for Monet-generated error and destructive foreground colors. Using .onError results in unreadable color contrasts (i.e. white on pink, red on red)

Fixes #425

## Type of change

- [x] Bugfix (Change which fixes a issue)
- [ ] New feature (Change which adds new functionality)
- [ ] Enhancement (Change which slightly improves existing code)
- [ ] Breaking change (This change will introduce incompatibility with existing functionality)

## Changelog

- Changed error and destructive foreground colors to .onErrorContainer

## Testing

- [x] I have tested my changes and verified that they work as expected