### PR TITLE
feat: use switch ative instead of state

### DIFF
--- a/data/ui/preferences_window.blp
+++ b/data/ui/preferences_window.blp
@@ -59,6 +59,7 @@ template GradiencePreferencesWindow : Adw.PreferencesWindow {
       Adw.ActionRow jsdeliver_row {
         title: _("Use an alternative server for downloading presets");
         subtitle: _("JSDelivr will be used instead of direct preset fetching from GitHub");
+        activatable-widget: jsdeliver_switch;
         Gtk.Switch jsdeliver_switch {
           valign: center;
         }

--- a/gradience/frontend/views/preferences_window.py
+++ b/gradience/frontend/views/preferences_window.py
@@ -74,25 +74,14 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
         self.theming_page.add(self.reset_preset_group)
 
     def setup_jsdeliver(self):
-        if self.app.use_jsdeliver:
-            self.jsdeliver_switch.set_state(True)
-        else:
-            self.jsdeliver_switch.set_state(False)
-
+        self.jsdeliver_switch.set_active(self.app.use_jsdeliver)
         self.jsdeliver_switch.connect(
             "state-set", self.on_jsdeliver_switch_toggled
         )
 
     def setup_theme_engines_group(self):
-        if "shell" in self.win.enabled_theme_engines:
-            self.gnome_shell_engine_switch.set_state(True)
-        else:
-            self.gnome_shell_engine_switch.set_state(False)
-
-        if "monet" in self.win.enabled_theme_engines:
-            self.monet_engine_switch.set_state(True)
-        else:
-            self.monet_engine_switch.set_state(False)
+        self.gnome_shell_engine_switch.set_active("shell" in self.win.enabled_theme_engines)
+        self.monet_engine_switch.set_active("monet" in self.win.enabled_theme_engines)
 
         self.gnome_shell_engine_switch.connect(
             "state-set", self.on_gnome_shell_engine_switch_toggled
@@ -111,17 +100,17 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
             "user-flatpak-theming-gtk3"
         )
 
-        self.gtk4_user_theming_switch.set_state(
+        self.gtk4_user_theming_switch.set_active(
             user_flatpak_theming_gtk4
         )
 
-        # self.gtk4_global_theming_switch.set_state(global_flatpak_theming_gtk4)
+        # self.gtk4_global_theming_switch.set_active(global_flatpak_theming_gtk4)
 
-        self.gtk3_user_theming_switch.set_state(
+        self.gtk3_user_theming_switch.set_active(
             user_flatpak_theming_gtk3
         )
 
-        # self.gtk3_global_theming_switch.set_state(global_flatpak_theming_gtk3)
+        # self.gtk3_global_theming_switch.set_active(global_flatpak_theming_gtk3)
 
         self.gtk4_user_theming_switch.connect(
             "state-set", self.on_gtk4_user_theming_switch_toggled
@@ -132,9 +121,9 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
         )
 
     def on_gtk4_user_theming_switch_toggled(self, *args):
-        state = self.gtk4_user_theming_switch.props.state
+        active = self.gtk4_user_theming_switch.props.active
 
-        if not state:
+        if not active:
             create_gtk_user_override(self.settings, "gtk4", self)
         else:
             remove_gtk_user_override(self.settings, "gtk4", self)
@@ -144,9 +133,9 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
             )
 
     def on_gtk3_user_theming_switch_toggled(self, *args):
-        state = self.gtk3_user_theming_switch.props.state
+        active = self.gtk3_user_theming_switch.props.active
 
-        if not state:
+        if not active:
             create_gtk_user_override(self.settings, "gtk3", self)
         else:
             remove_gtk_user_override(self.settings, "gtk3", self)
@@ -156,9 +145,9 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
             )
 
     def on_gtk4_global_theming_switch_toggled(self, *args):
-        state = self.gtk4_global_theming_switch.props.state
+        active = self.gtk4_global_theming_switch.props.active
 
-        if not state:
+        if not active:
             create_gtk_global_override(self.settings, "gtk4", self)
         else:
             remove_gtk_global_override(self.settings, "gtk4", self)
@@ -168,9 +157,9 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
             )
 
     def on_gtk3_global_theming_switch_toggled(self, *args):
-        state = self.gtk3_global_theming_switch.props.state
+        active = self.gtk3_global_theming_switch.props.active
 
-        if not state:
+        if not active:
             create_gtk_global_override(self.settings, "gtk3", self)
         else:
             remove_gtk_global_override(self.settings, "gtk3", self)
@@ -180,9 +169,9 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
             )
 
     def on_gnome_shell_engine_switch_toggled(self, *args):
-        state = self.gnome_shell_engine_switch.props.state
+        active = self.gnome_shell_engine_switch.props.active
 
-        if not state:
+        if not active:
             self.win.enabled_theme_engines.add("shell")
         else:
             self.win.enabled_theme_engines.remove("shell")
@@ -197,9 +186,9 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
         )
 
     def on_monet_engine_switch_toggled(self, *args):
-        state = self.monet_engine_switch.props.state
+        active = self.monet_engine_switch.props.active
 
-        if not state:
+        if not active:
             self.win.enabled_theme_engines.add("monet")
         else:
             self.win.enabled_theme_engines.remove("monet")
@@ -214,9 +203,9 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
         )
 
     def on_jsdeliver_switch_toggled(self, *args):
-        state = self.jsdeliver_switch.props.state
+        active = self.jsdeliver_switch.props.active
 
-        if not state:
+        if not active:
             self.app.use_jsdeliver = True
         else:
             self.app.use_jsdeliver = False


### PR DESCRIPTION
## Description

Changes the [Switches](https://docs.gtk.org/gtk4/class.Switch.html) to use the `active` property, which controls both color and position, instead of `state`, which only changes the switch color.

It also sets the `activatable-widget` on the jsdeliver ActionRows allowing the user to click anywhere to activate the switch.

## Type of change

<!-- What type of change does your pull request introduce? Put an `x` in the box that apply. -->
- [ ] Bugfix (Change which fixes a issue)
- [ ] New feature (Change which adds new functionality)
- [x] Enhancement (Change which slightly improves existing code)
- [ ] Breaking change (This change will introduce incompatibility with existing functionality)

## Changelog <!-- This is optional, but highly appreciated. -->

- Fixed a bug where Switches were not shown as active

## Testing

- [x] I have tested my changes and verified that they work as expected <!-- Make sure you did this step before marking your PR as ready for merge. -->

### How to test the changes

<!-- Optional, it can speed up review process if you provide the information on how to test your changes. -->
1. Open the preferences
2. Notice how the switches have both the correct position and color
