### PR TITLE
feat: set activatable widget on action rows

### DIFF
--- a/data/ui/builtin_preset_row.blp
+++ b/data/ui/builtin_preset_row.blp
@@ -3,6 +3,7 @@ using Adw 1;
 
 template GradienceBuiltinPresetRow : Adw.ActionRow {
   subtitle: _("Made by @GradienceTeam");
+  activatable-widget: apply_button;
 
   [suffix]
   Button apply_button {

--- a/data/ui/explore_preset_row.blp
+++ b/data/ui/explore_preset_row.blp
@@ -2,6 +2,8 @@ using Gtk 4.0;
 using Adw 1;
 
 template GradienceExplorePresetRow : Adw.ActionRow {
+  activatable-widget: apply_button;
+
   Box {
     spacing: 6;
 

--- a/data/ui/monet_theming_group.blp
+++ b/data/ui/monet_theming_group.blp
@@ -21,6 +21,7 @@ template GradienceMonetThemingGroup : Adw.PreferencesGroup {
 
     Adw.ActionRow file-chooser-row {
       title: _("Select an Image");
+      activatable-widget: file-chooser-button;
 
       [suffix]
       Button file-chooser-button {

--- a/data/ui/option_row.blp
+++ b/data/ui/option_row.blp
@@ -2,6 +2,8 @@ using Gtk 4.0;
 using Adw 1;
 
 template GradienceOptionRow : Adw.ActionRow {
+  activatable-widget: color-value;
+
   [suffix]
   MenuButton warning-button {
     valign: center;

--- a/data/ui/plugin_row.blp
+++ b/data/ui/plugin_row.blp
@@ -2,6 +2,8 @@ using Gtk 4.0;
 using Adw 1;
 
 template GradiencePluginRow : Adw.ActionRow {
+  activatable-widget: switch;
+
   [suffix]
   Switch switch {
     valign: center;

--- a/data/ui/shell_theming_group.blp
+++ b/data/ui/shell_theming_group.blp
@@ -21,6 +21,7 @@ template GradienceShellThemingGroup : Adw.PreferencesGroup {
 
     Adw.ActionRow custom-colors-row {
       title: _("Customize Shell Theme");
+      activatable-widget: custom-colors-button;
 
       [suffix]
       Button custom-colors-button {

--- a/gradience/frontend/widgets/option_row.py
+++ b/gradience/frontend/widgets/option_row.py
@@ -89,10 +89,9 @@ class GradienceOptionRow(Adw.ActionRow):
 
     @Gtk.Template.Callback()
     def on_text_value_toggled(self, *_args):
-        if self.text_value_toggle.get_active():
-            self.value_stack.set_visible_child(self.text_value)
-        else:
-            self.value_stack.set_visible_child(self.color_value)
+        widget = self.text_value if self.text_value_toggle.get_active() else self.color_value
+        self.value_stack.set_visible_child(widget)
+        self.set_activatable_widget(widget)
 
     def update_value(self, new_value, update_vars=False, **kwargs):
         rgba = Gdk.RGBA()


### PR DESCRIPTION
## Description

Sets the `activatable-widget` on ActionRows, allowing the user to click the row itself to activate the child widget. This brings it more inline with the default libadwaita ActionRows, e.g. ComboRow. It is only done for non-destructible actions. 


## Type of change

<!-- What type of change does your pull request introduce? Put an `x` in the box that apply. -->
- [x] Bugfix (Change which fixes a issue)
- [ ] New feature (Change which adds new functionality)
- [ ] Enhancement (Change which slightly improves existing code)
- [ ] Breaking change (This change will introduce incompatibility with existing functionality)

## Changelog <!-- This is optional, but highly appreciated. -->

- Fixed clicking on rows to activate their children 

## Testing

- [x] I have tested my changes and verified that they work as expected <!-- Make sure you did this step before marking your PR as ready for merge. -->

### How to test the changes

<!-- Optional, it can speed up review process if you provide the information on how to test your changes. -->
1. Open the app
2. Click on an ActionRow, e.g. an OptionRow
3. Notice how the ColorDialog is opened
