### PR TITLE
fix: Typo with jsdelivr being jsdeliver

### DIFF
--- a/data/com.github.GradienceTeam.Gradience.gschema.xml.in
+++ b/data/com.github.GradienceTeam.Gradience.gschema.xml.in
@@ -46,7 +46,7 @@
 		<key name="favourite" type="as">
 			<default>[]</default>
 		</key>
-		<key name="use-jsdeliver" type="b">
+		<key name="use-jsdelivr" type="b">
 			<default>false</default>
 		</key>
 	</schema>

--- a/data/ui/preferences_window.blp
+++ b/data/ui/preferences_window.blp
@@ -53,13 +53,13 @@ template GradiencePreferencesWindow : Adw.PreferencesWindow {
       }
     }
 
-    Adw.PreferencesGroup jsdeliver_group {
+    Adw.PreferencesGroup jsdelivr_group {
 
       title: _("Preset Fetching");
-      Adw.ActionRow jsdeliver_row {
+      Adw.ActionRow jsdelivr_row {
         title: _("Use an alternative server for downloading presets");
         subtitle: _("JSDelivr will be used instead of direct preset fetching from GitHub");
-        Gtk.Switch jsdeliver_switch {
+        Gtk.Switch jsdelivr_switch {
           valign: center;
         }
       }

--- a/gradience/backend/globals.py
+++ b/gradience/backend/globals.py
@@ -45,7 +45,7 @@ preset_repos_github = {
     "Curated": "https://github.com/GradienceTeam/Community/raw/next/curated.json"
 }
 
-preset_repos_jsdeliver = {
+preset_repos_jsdelivr = {
     "Official": "https://cdn.jsdelivr.net/gh/GradienceTeam/Community@next/official.json",
     "Curated": "https://cdn.jsdelivr.net/gh/GradienceTeam/Community@next/curated.json"
 }

--- a/gradience/backend/preset_downloader.py
+++ b/gradience/backend/preset_downloader.py
@@ -22,7 +22,7 @@ import json
 from gi.repository import GLib, Soup
 
 from gradience.backend.globals import presets_dir
-from gradience.backend.utils.networking import github_to_jsdeliver_url
+from gradience.backend.utils.networking import github_to_jsdelivr_url
 from gradience.backend.utils.common import to_slug_case
 
 from gradience.backend.logger import Logger
@@ -31,8 +31,8 @@ logging = Logger()
 
 
 class PresetDownloader:
-    def __init__(self, use_jsdeliver=False):
-        self.use_jsdeliver = use_jsdeliver
+    def __init__(self, use_jsdelivr=False):
+        self.use_jsdelivr = use_jsdelivr
         # Open Soup3 session
         self.session = Soup.Session()
 
@@ -69,8 +69,8 @@ class PresetDownloader:
             # Convert list back to dict
             preset_dict.update(dict(zip(to_dict, to_dict)))
 
-            if self.use_jsdeliver:
-                url = github_to_jsdeliver_url(url)
+            if self.use_jsdelivr:
+                url = github_to_jsdelivr_url(url)
 
             url_list.append(url)
 

--- a/gradience/backend/utils/networking.py
+++ b/gradience/backend/utils/networking.py
@@ -19,22 +19,22 @@
 from urllib.parse import urlparse
 
 
-def get_preset_repos(use_jsdeliver: bool) -> dict:
-    if use_jsdeliver:
-        from gradience.backend.globals import preset_repos_jsdeliver
-        preset_repos = preset_repos_jsdeliver
+def get_preset_repos(use_jsdelivr: bool) -> dict:
+    if use_jsdelivr:
+        from gradience.backend.globals import preset_repos_jsdelivr
+        preset_repos = preset_repos_jsdelivr
     else:
         from gradience.backend.globals import preset_repos_github
         preset_repos = preset_repos_github
 
     return preset_repos
 
-def github_to_jsdeliver_url(github_url: str) -> str:
+def github_to_jsdelivr_url(github_url: str) -> str:
     """
     Converts Github raw data URL link to JSDelivr CDN link.
     """
 
-    jsdeliver_url = None
+    jsdelivr_url = None
 
     # https://github.com/GradienceTeam/Community/raw/next/official/builder.json =>
     # https://cdn.jsdelivr.net/gh/GradienceTeam/Community@next/official/builder.json
@@ -43,6 +43,6 @@ def github_to_jsdeliver_url(github_url: str) -> str:
         path = urlparse(github_url).path
         user, repo, _, branch, *path = path.strip('/').split('/')
         path = "/".join(path)
-        jsdeliver_url = JSDELIVER_FORMAT.format(user=user, repo=repo, branch=branch, path=path)
+        jsdelivr_url = JSDELIVER_FORMAT.format(user=user, repo=repo, branch=branch, path=path)
 
-    return jsdeliver_url
+    return jsdelivr_url

--- a/gradience/frontend/cli/cli.in
+++ b/gradience/frontend/cli/cli.in
@@ -136,7 +136,7 @@ class CLI:
         overrides_group.add_argument("-e", "--enable-theming", choices=["gtk4", "gtk3", "both"], help="enable overrides for Flatpak theming")
         overrides_group.add_argument("-d", "--disable-theming", choices=["gtk4", "gtk3", "both"], help="disable overrides for Flatpak theming")
 
-        self.preset_repos = get_preset_repos(self.settings.get_boolean("use-jsdeliver"))
+        self.preset_repos = get_preset_repos(self.settings.get_boolean("use-jsdelivr"))
 
         self.__parse_args()
 
@@ -335,7 +335,7 @@ class CLI:
         repos_amount = len(self.preset_repos.items())
         for repo_name, repo in self.preset_repos.items():
             try:
-                explore_presets, urls = PresetDownloader(self.settings.get_boolean("use-jsdeliver")).fetch_presets(repo)
+                explore_presets, urls = PresetDownloader(self.settings.get_boolean("use-jsdelivr")).fetch_presets(repo)
             except (GLib.GError, json.JSONDecodeError) as e:
                 logging.error("An error occurred while fetching presets from remote repository.", exc=e)
                 exit(1)

--- a/gradience/frontend/main.py
+++ b/gradience/frontend/main.py
@@ -96,7 +96,7 @@ class GradienceApplication(Adw.Application):
 
         self.style_manager = Adw.StyleManager.get_default()
 
-        self.use_jsdeliver = self.settings.get_boolean("use-jsdeliver")
+        self.use_jsdelivr = self.settings.get_boolean("use-jsdelivr")
 
     def do_activate(self):
         """Called when the application is activated."""

--- a/gradience/frontend/views/preferences_window.py
+++ b/gradience/frontend/views/preferences_window.py
@@ -44,7 +44,7 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
     gtk3_user_theming_switch = Gtk.Template.Child()
     gtk3_global_theming_switch = Gtk.Template.Child()
 
-    jsdeliver_switch = Gtk.Template.Child()
+    jsdelivr_switch = Gtk.Template.Child()
 
     monet_engine_switch = Gtk.Template.Child()
     gnome_shell_engine_switch = Gtk.Template.Child()
@@ -66,21 +66,21 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
         self.setup_flatpak_group()
         self.setup_theme_engines_group()
         self.setup_reset_preset_group()
-        self.setup_jsdeliver()
+        self.setup_jsdelivr()
 
     def setup_reset_preset_group(self):
         self.reset_preset_group = GradienceResetPresetGroup(self)
 
         self.theming_page.add(self.reset_preset_group)
 
-    def setup_jsdeliver(self):
-        if self.app.use_jsdeliver:
-            self.jsdeliver_switch.set_state(True)
+    def setup_jsdelivr(self):
+        if self.app.use_jsdelivr:
+            self.jsdelivr_switch.set_state(True)
         else:
-            self.jsdeliver_switch.set_state(False)
+            self.jsdelivr_switch.set_state(False)
 
-        self.jsdeliver_switch.connect(
-            "state-set", self.on_jsdeliver_switch_toggled
+        self.jsdelivr_switch.connect(
+            "state-set", self.on_jsdelivr_switch_toggled
         )
 
     def setup_theme_engines_group(self):
@@ -213,16 +213,16 @@ class GradiencePreferencesWindow(Adw.PreferencesWindow):
                 f"enabled-theme-engines: {self.settings.get_value('enabled-theme-engines')}"
         )
 
-    def on_jsdeliver_switch_toggled(self, *args):
-        state = self.jsdeliver_switch.props.state
+    def on_jsdelivr_switch_toggled(self, *args):
+        state = self.jsdelivr_switch.props.state
 
         if not state:
-            self.app.use_jsdeliver = True
+            self.app.use_jsdelivr = True
         else:
-            self.app.use_jsdeliver = False
+            self.app.use_jsdelivr = False
 
-        self.settings.set_boolean("use-jsdeliver", self.app.use_jsdeliver)
+        self.settings.set_boolean("use-jsdelivr", self.app.use_jsdelivr)
 
         logging.debug(
-                f"use-jsdeliver: {self.settings.get_value('use-jsdeliver')}"
+                f"use-jsdelivr: {self.settings.get_value('use-jsdelivr')}"
         )

--- a/gradience/frontend/views/presets_manager_window.py
+++ b/gradience/frontend/views/presets_manager_window.py
@@ -84,7 +84,7 @@ class GradiencePresetWindow(Adw.Window):
         self.user_repositories = self.settings.get_value("repos").unpack()
         self.enabled_repos = self.settings.get_value("enabled-repos").unpack()
 
-        self.preset_repos = get_preset_repos(self.settings.get_boolean("use-jsdeliver"))
+        self.preset_repos = get_preset_repos(self.settings.get_boolean("use-jsdelivr"))
 
         self.setup_signals()
         self.setup()
@@ -148,7 +148,7 @@ class GradiencePresetWindow(Adw.Window):
                 badge = "white"
 
             try:
-                explore_presets, urls = PresetDownloader(self.settings.get_boolean("use-jsdeliver")).fetch_presets(repo)
+                explore_presets, urls = PresetDownloader(self.settings.get_boolean("use-jsdelivr")).fetch_presets(repo)
             except GLib.GError as e:
                 if e.code == 1:
                     self.offline = True


### PR DESCRIPTION
## Description

Fxies JSDelivr typo (being `jsdeliver` instead of `jsdelivr`)

_Probably should be merged after https://github.com/GradienceTeam/Gradience/pull/792_

## Type of change

<!-- What type of change does your pull request introduce? Put an `x` in the appropriate box . -->
- [x] Bugfix (Change which fixes an issue)
- [ ] New feature (Change which adds new functionality)
- [ ] Enhancement (Change which slightly improves existing code)
- [ ] Breaking change (This change will introduce incompatibility with existing functionality)

## Changelog <!-- This is optional, but highly appreciated. -->

- Fixed …
- Added …

## Testing

- [x] I have tested my changes and verified that they work as expected <!-- Make sure you did this step before marking your PR as ready for merge. -->

### How to test the changes

<!-- Optional, it can speed up review process if you provide the information on how to test your changes. -->
No information provided.
