### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/com.github.GradienceTeam.Gradience.appdata.xml.in.in
+++ b/data/com.github.GradienceTeam.Gradience.appdata.xml.in.in
@@ -76,7 +76,7 @@
 
   <releases>
     <release version="0.8.0-beta2" date="2024-01-4" type="development">
-      <description translatable="no">
+      <description translate="no">
         <p>Gradience 0.8.0-beta2 release is the second beta for upcoming major release.</p>
         <ul>
           <li>See GitHub releases for more info</li>
@@ -84,7 +84,7 @@
       </description>
     </release>"
     <release version="0.8.0-beta1" date="2023-06-16" type="development">
-      <description translatable="no">
+      <description translate="no">
         <p>Gradience 0.8.0-beta1 release is the first beta for upcoming major release.</p>
         <ul>
           <li>See GitHub releases for more info</li>
@@ -92,7 +92,7 @@
       </description>
     </release>
     <release version="0.4.1" date="2023-3-5" type="stable">
-      <description translatable="no">
+      <description translate="no">
         <p>This is a small bug fix release mainly intended for package maintainers.</p>
         <ul>
           <li>Only configure local CLI if buildtype is set to debug</li>
@@ -106,7 +106,7 @@
       </description>
     </release>
     <release version="0.4.0" date="2023-2-8" type="stable">
-      <description translatable="no">
+      <description translate="no">
         <p>Gradience version 0.4.0 introduces some bug fixes and general quality of life improvement changes:</p>
         <ul>
           <li>Added CLI interface, useful for creating scripts or for those who prefer terminal tools</li>
@@ -124,7 +124,7 @@
       </description>
     </release>
     <release version="0.3.3" date="2022-12-3" type="stable">
-      <description translatable="no">
+      <description translate="no">
         <p>Gradience 0.3.3 release is a minor translations update and UI improvement release:</p>
         <ul>
           <li>The Firefox GNOME theme plugin now parses profiles from profiles.ini</li>
@@ -138,7 +138,7 @@
       </description>
     </release>
     <release version="0.3.2" date="2022-11-10" type="stable">
-      <description translatable="no">
+      <description translate="no">
         <p>Gradience 0.3.2 release fixes some major issues and introduces some under-the-hood improvements:</p>
         <ul>
           <li>The Firefox GNOME theme plugin now correctly parses installations with multiple profiles</li>
@@ -162,7 +162,7 @@
       </description>
     </release>
     <release version="0.3.1" date="2022-10-07" type="stable">
-      <description translatable="no">
+      <description translate="no">
         <p>Gradience 0.3.1 release focuses on user interface polish and bug fixes, as well as some new features:</p>
         <ul>
           <li>Added ability to star preset to display it in Palette</li>
@@ -185,7 +185,7 @@
       </description>
     </release>
     <release version="0.3.0" date="2022-09-16" type="stable">
-      <description translatable="no">
+      <description translate="no">
         <p>Gradience 0.3.0 is a major update with many new features and improvements. Here are some of them:</p>
         <ul>
           <li>Added plugins support, this allows the creation of plugins to customize other apps</li>
@@ -202,7 +202,7 @@
       </description>
     </release>
     <release version="0.2.1" date="2022-08-30" type="stable">
-      <description translatable="no">
+      <description translate="no">
         <p>A small bug fix release of Gradience.</p>
         <ul>
           <li>Small improvements to the welcome screen</li>
@@ -211,7 +211,7 @@
       </description>
     </release>
     <release version="0.2.0" date="2022-08-26" type="stable">
-      <description translatable="no">
+      <description translate="no">
         <p>New Release of Gradience.</p>
         <ul>
           <li>Rebrand</li>
@@ -224,7 +224,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2022-08-12" type="stable">
-      <description translatable="no">
+      <description translate="no">
         <p>First release of Gradience.</p>
         <ul>
           <li>Add AdwViewSwitcher in the header bar</li>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

## Description

<!-- Describe your changes in detail here. -->

Fixes #(issue) <!-- Remove this, if your PR doesn't fix any tracked issue. -->

## Type of change

<!-- What type of change does your pull request introduce? Put an `x` in the appropriate box . -->
- [ ] Bugfix (Change which fixes an issue)
- [ ] New feature (Change which adds new functionality)
- [ ] Enhancement (Change which slightly improves existing code)
- [ ] Breaking change (This change will introduce incompatibility with existing functionality)

## Changelog <!-- This is optional, but highly appreciated. -->

- Fixed …
- Added …

## Testing

- [ ] I have tested my changes and verified that they work as expected <!-- Make sure you did this step before marking your PR as ready for merge. -->

### How to test the changes

<!-- Optional, it can speed up review process if you provide the information on how to test your changes. -->
No information provided.
